### PR TITLE
Add 301 redirects to formguide.tools.football

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,12 @@
 const { transpile } = require("typescript");
+const { buildRedirects } = require("./redirects");
 
 module.exports = {
   images: {
     domains: ["media.api-sports.io"],
   },
   transpilePackages: ["@mui/x-data-grid"],
+  async redirects() {
+    return buildRedirects();
+  },
 };

--- a/redirects.js
+++ b/redirects.js
@@ -1,0 +1,75 @@
+// 301 redirects from legacy formguide routes to formguide.tools.football.
+// Maps the old per-league route prefix (e.g. /sp_la_liga/...) to the new
+// site, where the league is a path suffix (e.g. /standings/laliga).
+
+const TARGET_HOST = "https://formguide.tools.football";
+
+// Old league code -> new league slug on formguide.tools.football.
+// Old codes that have no equivalent on the new site are intentionally omitted.
+const LEAGUE_MAPPING = {
+  mls: "mls",
+  nwsl: "nwsl",
+  mlsnp: "mlsnp",
+  epl: "epl",
+  ligamx: "ligamx",
+  uslc: "uslchampionship",
+  usl1: "uslleagueone",
+  usl2: "uslleaguetwo",
+  de_bundesliga: "bundesliga",
+  de_frauen_bundesliga: "frauenbundesliga",
+  en_fa_wsl: "fawsl",
+  en_championship: "championship",
+  en_league_one: "leagueone",
+  en_league_two: "leaguetwo",
+  en_national: "nationalleague",
+  fr_ligue_1: "ligue1",
+  sp_la_liga: "laliga",
+  it_serie_a: "seriea",
+  it_serie_a_women: "serieawomen",
+};
+
+// Each rule maps a path under /[league]/... on the old site to a path on the
+// new site. `to` is a function so rules can compose the new league slug and
+// any captured params (e.g. :period) however they need.
+const PATH_RULES = [
+  {
+    from: "/projected/points",
+    to: (league) => `/simulated/${league}`,
+  },
+  {
+    from: "/table/position",
+    to: (league) => `/standings/${league}`,
+  },
+  {
+    from: "/table",
+    to: (league) => `/standings/${league}`,
+  },
+  {
+    from: "/chart/:period",
+    to: (league, params) => `/rolling/${league}?period=${params.period}`,
+  },
+];
+
+function buildRedirects() {
+  const redirects = [];
+  for (const [oldLeague, newLeague] of Object.entries(LEAGUE_MAPPING)) {
+    for (const rule of PATH_RULES) {
+      // Use a placeholder we substitute back so we can pass param names through
+      // path-to-regexp without Next.js trying to interpret them in `destination`.
+      const paramNames = [...rule.from.matchAll(/:([a-zA-Z]+)/g)].map(
+        (m) => m[1],
+      );
+      const params = Object.fromEntries(
+        paramNames.map((name) => [name, `:${name}`]),
+      );
+      redirects.push({
+        source: `/${oldLeague}${rule.from}`,
+        destination: `${TARGET_HOST}${rule.to(newLeague, params)}`,
+        permanent: true,
+      });
+    }
+  }
+  return redirects;
+}
+
+module.exports = { buildRedirects, LEAGUE_MAPPING, PATH_RULES, TARGET_HOST };


### PR DESCRIPTION
## Summary
- Adds a `redirects()` block to `next.config.js` backed by a new `redirects.js` module
- Maps legacy `/[league]/...` routes to the new site at `https://formguide.tools.football`, including league-slug remapping (e.g. `sp_la_liga` → `laliga`, `de_bundesliga` → `bundesliga`)
- Old-league codes that have no equivalent on the new site (e.g. `nisa`, `de_2_bundesliga`, `sp_segunda`) are intentionally left out

### Path rules in this PR
| Old | New |
| --- | --- |
| `/[league]/projected/points` | `/simulated/[league]` |
| `/[league]/table/position` | `/standings/[league]` |
| `/[league]/table` | `/standings/[league]` |
| `/[league]/chart/[period]` | `/rolling/[league]?period=[period]` |

The `redirects.js` module is structured so additional rules and league mappings can be appended easily as more routes are migrated. Generates 76 redirects (19 mapped leagues × 4 rules).

## Test plan
- [ ] `npm run build` succeeds with the new `redirects()` config
- [ ] Hitting `/sp_la_liga/table` 301s to `https://formguide.tools.football/standings/laliga`
- [ ] Hitting `/epl/chart/5` 301s to `https://formguide.tools.football/rolling/epl?period=5`
- [ ] Spot-check a couple of other league/route combinations

https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD

---
_Generated by [Claude Code](https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD)_