### PR TITLE
Add /[league]/table/advanced redirect to standings

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -41,6 +41,10 @@ const PATH_RULES = [
     to: (league) => `/standings/${league}`,
   },
   {
+    from: "/table/advanced",
+    to: (league) => `/standings/${league}`,
+  },
+  {
     from: "/table",
     to: (league) => `/standings/${league}`,
   },


### PR DESCRIPTION
## Summary
- Adds a new path rule: `/[league]/table/advanced` → `/standings/[league]` on `formguide.tools.football`

Now generates 95 redirects (19 mapped leagues × 5 rules).

## Test plan
- [ ] Hitting `/sp_la_liga/table/advanced` 301s to `https://formguide.tools.football/standings/laliga`

https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD

---
_Generated by [Claude Code](https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD)_