### PR TITLE
Add /[league]/projected-standings redirect

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -37,6 +37,10 @@ const PATH_RULES = [
     to: (league) => `/simulated/${league}`,
   },
   {
+    from: "/projected-standings",
+    to: (league) => `/simulated/${league}`,
+  },
+  {
     from: "/table/position",
     to: (league) => `/standings/${league}`,
   },


### PR DESCRIPTION
## Summary
- Adds `/[league]/projected-standings` → `/simulated/[league]` on `formguide.tools.football`

Total redirects now: 114 (19 mapped leagues × 6 rules).

## Test plan
- [ ] `/sp_la_liga/projected-standings` 301s to `https://formguide.tools.football/simulated/laliga`

https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD

---
_Generated by [Claude Code](https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD)_