### PR TITLE
Add /[league]/record/since/[date] redirect

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -56,6 +56,10 @@ const PATH_RULES = [
     from: "/chart/:period",
     to: (league, params) => `/rolling/${league}?period=${params.period}`,
   },
+  {
+    from: "/record/since/:date",
+    to: (league) => `/standings/${league}`,
+  },
 ];
 
 function buildRedirects() {


### PR DESCRIPTION
## Summary
- Adds `/[league]/record/since/[date]` → `/standings/[league]` on `formguide.tools.football`
- The date param is dropped in this redirect. (Equivalent "since [date]" functionality does exist on the new site, but we're not forwarding the date for now — can be revisited if/when we want to map to the specific destination route.)

Total redirects now: 133 (19 mapped leagues × 7 rules).

## Test plan
- [ ] `/mls/record/since/2026-01-01` 301s to `https://formguide.tools.football/standings/mls`

https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD

---
_Generated by [Claude Code](https://claude.ai/code/session_017PZzkT9JkCbEypkbbR4oHD)_