### PR TITLE
Add 301 redirects for legacy pages with new-site equivalents

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -31,7 +31,10 @@ const LEAGUE_MAPPING = {
 // Each rule maps a path under /[league]/... on the old site to a path on the
 // new site. `to` is a function so rules can compose the new league slug and
 // any captured params (e.g. :period) however they need.
+// Order matters: more specific paths must come before generic ones, since
+// Next.js applies the first matching rule.
 const PATH_RULES = [
+  // Projections / simulated standings
   {
     from: "/projected/points",
     to: (league) => `/simulated/${league}`,
@@ -39,6 +42,16 @@ const PATH_RULES = [
   {
     from: "/projected-standings",
     to: (league) => `/simulated/${league}`,
+  },
+  {
+    from: "/projections",
+    to: (league) => `/simulated/${league}`,
+  },
+
+  // Standings / table
+  {
+    from: "/table/chart",
+    to: (league) => `/over-time/${league}`,
   },
   {
     from: "/table/position",
@@ -53,12 +66,134 @@ const PATH_RULES = [
     to: (league) => `/standings/${league}`,
   },
   {
+    from: "/record/since/:date",
+    to: (league) => `/standings/${league}`,
+  },
+
+  // Over-time (cumulative points / position chart)
+  {
+    from: "/points/cumulative",
+    to: (league) => `/over-time/${league}`,
+  },
+
+  // Rolling form (chart-style with a period)
+  {
     from: "/chart/:period",
     to: (league, params) => `/rolling/${league}?period=${params.period}`,
   },
   {
-    from: "/record/since/:date",
-    to: (league) => `/standings/${league}`,
+    from: "/gf-chart/:period",
+    to: (league, params) => `/rolling/${league}?period=${params.period}`,
+  },
+  {
+    from: "/ga-chart/:period",
+    to: (league, params) => `/rolling/${league}?period=${params.period}`,
+  },
+  {
+    from: "/gd-chart/:period",
+    to: (league, params) => `/rolling/${league}?period=${params.period}`,
+  },
+  {
+    from: "/xg/rolling/:stat/:period",
+    to: (league, params) => `/rolling/${league}?period=${params.period}`,
+  },
+  {
+    from: "/first-goal/rolling/:type/:period",
+    to: (league, params) => `/rolling/${league}?period=${params.period}`,
+  },
+  {
+    from: "/stats/rolling/finishing",
+    to: (league) => `/rolling/${league}`,
+  },
+  {
+    from: "/stats/rolling/:type",
+    to: (league) => `/rolling/${league}`,
+  },
+
+  // League stats (xG / GF / GA / GD / scatter / comparison / finishing)
+  {
+    from: "/stats/comparison/:type",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/stats/finishing",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/stats/scatter/:type",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/stats/:type",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/xg/for",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/xg/against",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/xg/difference",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/gf",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/ga",
+    to: (league) => `/stats/${league}`,
+  },
+  {
+    from: "/gd",
+    to: (league) => `/stats/${league}`,
+  },
+
+  // Player stats (player-minutes lives at the league-agnostic /stats route)
+  {
+    from: "/player-minutes/:team/rolling",
+    to: () => `/stats`,
+  },
+  {
+    from: "/player-minutes/:team",
+    to: () => `/stats`,
+  },
+  {
+    from: "/player-minutes",
+    to: () => `/stats`,
+  },
+
+  // Versus / head-to-head
+  {
+    from: "/versus/gd",
+    to: (league) => `/h2h/${league}`,
+  },
+  {
+    from: "/versus/record",
+    to: (league) => `/h2h/${league}`,
+  },
+  {
+    from: "/versus",
+    to: (league) => `/h2h/${league}`,
+  },
+
+  // Fixtures -> schedule
+  {
+    from: "/fixtures/today",
+    to: (league) => `/schedule/${league}`,
+  },
+  {
+    from: "/fixtures",
+    to: (league) => `/schedule/${league}`,
+  },
+
+  // Strength of schedule (approximate match for opponent-PPG view)
+  {
+    from: "/ppg/opponent",
+    to: (league) => `/strength-of-schedule/${league}`,
   },
 ];
 


### PR DESCRIPTION
## Summary

Extends `PATH_RULES` in `redirects.js` to cover legacy routes that have a clear (or close) match on formguide.tools.football. Previously only 7 path patterns were redirected; this adds ~30 more, bringing the total generated redirects from ~140 to 684.

### New mappings

- **Fixtures → schedule**: `/fixtures`, `/fixtures/today` → `/schedule/{league}`
- **Versus → h2h**: `/versus`, `/versus/gd`, `/versus/record` → `/h2h/{league}`
- **Projections → simulated**: `/projections` → `/simulated/{league}`
- **Over-time**: `/points/cumulative`, `/table/chart` → `/over-time/{league}`
- **League stats**: `/stats/:type`, `/stats/comparison/:type`, `/stats/finishing`, `/stats/scatter/:type`, `/xg/for`, `/xg/against`, `/xg/difference`, `/gf`, `/ga`, `/gd` → `/stats/{league}`
- **Player stats**: `/player-minutes`, `/player-minutes/:team`, `/player-minutes/:team/rolling` → `/stats`
- **Rolling form**: `/gf-chart/:period`, `/ga-chart/:period`, `/gd-chart/:period`, `/xg/rolling/:stat/:period`, `/first-goal/rolling/:type/:period`, `/stats/rolling/:type`, `/stats/rolling/finishing` → `/rolling/{league}` (with period query param where available)
- **Strength of schedule** (approximate): `/ppg/opponent` → `/strength-of-schedule/{league}`

Rule order is specific-before-generic so `/stats/finishing`, `/stats/comparison/:type`, etc. match before the catch-all `/stats/:type`.

### Pages intentionally NOT redirected

Legacy "novelty / deep-dive" pages with no equivalent on the new site remain on the legacy domain (facts, game-states, halftime splits, since-result, substitutes, referees, odds, plus-minus, most PPG views, game-days, cumulative GF/GA/GD, by-half breakdowns, first-goal type pages, fixture detail, changelog, admin). A separate inventory of these is being prepared so they can be considered for implementation on the new site.

## Test plan

- [x] `node -e "require('./redirects').buildRedirects()"` runs without error and produces 684 redirects
- [ ] Spot-check a handful of redirects in a deployed preview (e.g. `/mls/fixtures`, `/epl/versus`, `/sp_la_liga/xg/for`, `/mls/gf-chart/5`)
- [ ] Confirm no regression in already-working redirects (`/mls/table`, `/epl/projected/points`, `/mls/chart/5`)


---
_Generated by [Claude Code](https://claude.ai/code/session_0137Hp1aYfJLojywe8eZqHZ8)_